### PR TITLE
增加对城市名多音字的处理

### DIFF
--- a/app/build.gradle
+++ b/app/build.gradle
@@ -6,7 +6,7 @@ android {
 
     defaultConfig {
         applicationId "com.mcxtzhang.itemdecorationindexbar"
-        minSdkVersion 14
+        minSdkVersion 16
         targetSdkVersion 23
         versionCode 1
         versionName "1.0"

--- a/app/src/main/java/mcxtzhang/itemdecorationdemo/model/CityBean.java
+++ b/app/src/main/java/mcxtzhang/itemdecorationdemo/model/CityBean.java
@@ -43,6 +43,11 @@ public class CityBean extends BaseIndexPinyinBean {
     }
 
     @Override
+    public boolean isNeedToConvertCity() {
+        return false;
+    }
+
+    @Override
     public boolean isNeedToPinyin() {
         return !isTop;
     }

--- a/app/src/main/java/mcxtzhang/itemdecorationdemo/model/MeiTuanBean.java
+++ b/app/src/main/java/mcxtzhang/itemdecorationdemo/model/MeiTuanBean.java
@@ -33,4 +33,9 @@ public class MeiTuanBean extends BaseIndexPinyinBean {
     public String getTarget() {
         return city;
     }
+
+    @Override
+    public boolean isNeedToConvertCity() {
+        return true;
+    }
 }

--- a/app/src/main/java/mcxtzhang/itemdecorationdemo/model/MeituanHeaderBean.java
+++ b/app/src/main/java/mcxtzhang/itemdecorationdemo/model/MeituanHeaderBean.java
@@ -46,6 +46,11 @@ public class MeituanHeaderBean extends BaseIndexPinyinBean {
     }
 
     @Override
+    public boolean isNeedToConvertCity() {
+        return true;
+    }
+
+    @Override
     public boolean isNeedToPinyin() {
         return false;
     }

--- a/app/src/main/java/mcxtzhang/itemdecorationdemo/ui/MeituanSelectCityActivity.java
+++ b/app/src/main/java/mcxtzhang/itemdecorationdemo/ui/MeituanSelectCityActivity.java
@@ -12,6 +12,7 @@ import android.widget.TextView;
 import android.widget.Toast;
 
 import com.mcxtzhang.indexlib.IndexBar.bean.BaseIndexPinyinBean;
+import com.mcxtzhang.indexlib.IndexBar.helper.IndexBarDataHelperImpl;
 import com.mcxtzhang.indexlib.IndexBar.widget.IndexBar;
 import com.mcxtzhang.indexlib.suspension.SuspensionDecoration;
 
@@ -212,8 +213,10 @@ public class MeituanSelectCityActivity extends AppCompatActivity {
         for (int i = 0; i < 5; i++) {
             mBodyDatas.add(new MeiTuanBean("东京"));
             mBodyDatas.add(new MeiTuanBean("大阪"));
+            mBodyDatas.add(new MeiTuanBean("重庆"));
         }
         //先排序
+        mIndexBar.setDataHelper(new IndexBarDataHelperImpl(this));
         mIndexBar.getDataHelper().sortSourceDatas(mBodyDatas);
         mSourceDatas.clear();
         mSourceDatas.addAll(mHeaderDatas);

--- a/indexlib/build.gradle
+++ b/indexlib/build.gradle
@@ -5,7 +5,7 @@ android {
     buildToolsVersion "24.0.3"
 
     defaultConfig {
-        minSdkVersion 14
+        minSdkVersion 16
         targetSdkVersion 24
         versionCode 1
         versionName "1.0"
@@ -25,5 +25,6 @@ dependencies {
     compile fileTree(include: ['*.jar'], dir: 'libs')
     compile 'com.android.support:appcompat-v7:24.2.1'
     compile 'com.android.support:recyclerview-v7:24.2.1'
-    compile 'com.github.promeg:tinypinyin:1.0.0' // ~80KB
+    compile 'com.github.promeg:tinypinyin:2.0.3'
+    compile 'com.github.promeg:tinypinyin-lexicons-android-cncity:2.0.3'
 }

--- a/indexlib/src/main/java/com/mcxtzhang/indexlib/IndexBar/bean/BaseIndexPinyinBean.java
+++ b/indexlib/src/main/java/com/mcxtzhang/indexlib/IndexBar/bean/BaseIndexPinyinBean.java
@@ -31,5 +31,8 @@ public abstract class BaseIndexPinyinBean extends BaseIndexBean {
     //需要转化成拼音的目标字段
     public abstract String getTarget();
 
+    //如果需要转换城市名(包括多音字)->拼音，返回true
+    public abstract boolean isNeedToConvertCity();
+
 
 }

--- a/indexlib/src/main/java/com/mcxtzhang/indexlib/IndexBar/helper/IndexBarDataHelperImpl.java
+++ b/indexlib/src/main/java/com/mcxtzhang/indexlib/IndexBar/helper/IndexBarDataHelperImpl.java
@@ -1,6 +1,9 @@
 package com.mcxtzhang.indexlib.IndexBar.helper;
 
+import android.content.Context;
+
 import com.github.promeg.pinyinhelper.Pinyin;
+import com.github.promeg.tinypinyin.lexicons.android.cncity.CnCityDict;
 import com.mcxtzhang.indexlib.IndexBar.bean.BaseIndexPinyinBean;
 
 import java.util.Collections;
@@ -20,6 +23,12 @@ import java.util.List;
  */
 
 public class IndexBarDataHelperImpl implements IIndexBarDataHelper {
+    private Context mContext;
+    public IndexBarDataHelperImpl(){}
+
+    public IndexBarDataHelperImpl(Context context){
+        this.mContext = context;
+    }
     /**
      * 如果需要，
      * 字符->拼音，
@@ -32,18 +41,24 @@ public class IndexBarDataHelperImpl implements IIndexBarDataHelper {
             return this;
         }
         int size = datas.size();
+        if (mContext != null)
+            Pinyin.init(Pinyin.newConfig().with(CnCityDict.getInstance(mContext)));
         for (int i = 0; i < size; i++) {
             BaseIndexPinyinBean indexPinyinBean = datas.get(i);
             StringBuilder pySb = new StringBuilder();
             //add by zhangxutong 2016 11 10 如果不是top 才转拼音，否则不用转了
             if (indexPinyinBean.isNeedToPinyin()) {
                 String target = indexPinyinBean.getTarget();//取出需要被拼音化的字段
-                //遍历target的每个char得到它的全拼音
-                for (int i1 = 0; i1 < target.length(); i1++) {
-                    //利用TinyPinyin将char转成拼音
-                    //查看源码，方法内 如果char为汉字，则返回大写拼音
-                    //如果c不是汉字，则返回String.valueOf(c)
-                    pySb.append(Pinyin.toPinyin(target.charAt(i1)).toUpperCase());
+                if(indexPinyinBean.isNeedToConvertCity()){
+                    pySb.append(Pinyin.toPinyin(target,"").toUpperCase());
+                }else {
+                    //遍历target的每个char得到它的全拼音
+                    for (int i1 = 0; i1 < target.length(); i1++) {
+                        //利用TinyPinyin将char转成拼音
+                        //查看源码，方法内 如果char为汉字，则返回大写拼音
+                        //如果c不是汉字，则返回String.valueOf(c)
+                        pySb.append(Pinyin.toPinyin(target.charAt(i1)).toUpperCase());
+                    }
                 }
                 indexPinyinBean.setBaseIndexPinyin(pySb.toString());//设置城市名全拼音
             } else {


### PR DESCRIPTION
对于城市选择多音字的处理，我参照了引用包中'TinyPinyin'的处理方案:[多音字快速处理方案](http://promeg.io/2017/03/20/tinypinyin-part-2/)，增加了中文城市的字典库:`com.github.promeg:tinypinyin-lexicons-android-cncity:2.0.3`。
不过因为字典库的minSdk=16的原因，这里我将项目的minSdk也'粗暴'的改成了16(- -!)。
增加了`BaseIndexPinyinBean`对于子类是否对城市名进行多音字处理:` public abstract boolean isNeedToConvertCity();`。
处理比较简陋，请多指教 ：）